### PR TITLE
Enable dual-model diffusion with step ratio

### DIFF
--- a/app/sana_pipeline.py
+++ b/app/sana_pipeline.py
@@ -178,6 +178,8 @@ class SanaPipeline(nn.Module):
         generator=torch.Generator().manual_seed(42),
         latents=None,
         use_resolution_binning=True,
+        secondary_model=None,
+        model_switch_ratio=0.7,
     ):
         self.ori_height, self.ori_width = height, width
         if use_resolution_binning:
@@ -275,6 +277,7 @@ class SanaPipeline(nn.Module):
                         steps=num_inference_steps,
                     )
                 elif self.vis_sampler == "flow_dpm-solver":
+                    switch_step = int(num_inference_steps * model_switch_ratio)
                     scheduler = DPMS(
                         self.model,
                         condition=caption_embs,
@@ -286,6 +289,8 @@ class SanaPipeline(nn.Module):
                         model_type="flow",
                         model_kwargs=model_kwargs,
                         schedule="FLOW",
+                        second_model=secondary_model,
+                        switch_step=switch_step,
                     )
                     scheduler.register_progress_bar(self.progress_fn)
                     sample = scheduler.sample(

--- a/diffusion/model/dpm_solver.py
+++ b/diffusion/model/dpm_solver.py
@@ -613,7 +613,11 @@ class DPM_Solver:
             Burcu Karagol Ayan, S Sara Mahdavi, Rapha Gontijo Lopes, et al. Photorealistic text-to-image diffusion models
             with deep language understanding. arXiv preprint arXiv:2205.11487, 2022b.
         """
-        self.model = lambda x, t: model_fn(x, t.expand(x.shape[0]))
+        self.base_model = lambda x, t: model_fn(x, t.expand(x.shape[0]))
+        self.model = self.base_model
+        self.second_model = None
+        self.switch_step = None
+        self.cur_step = 0
         self.noise_schedule = noise_schedule
         assert algorithm_type in ["dpmsolver", "dpmsolver++"]
         self.algorithm_type = algorithm_type
@@ -625,6 +629,18 @@ class DPM_Solver:
         self.dynamic_thresholding_ratio = dynamic_thresholding_ratio
         self.thresholding_max_val = thresholding_max_val
         self.register_progress_bar()
+
+    def set_secondary_model(self, model_fn, switch_step):
+        """Register a secondary model used after a given step."""
+        self.second_model = lambda x, t: model_fn(x, t.expand(x.shape[0]))
+        self.switch_step = switch_step
+
+        def combined_model(x, t):
+            if self.second_model is not None and self.cur_step >= self.switch_step:
+                return self.second_model(x, t)
+            return self.base_model(x, t)
+
+        self.model = combined_model
 
     def register_progress_bar(self, progress_fn=None):
         """
@@ -1526,6 +1542,7 @@ class DPM_Solver:
                 step = 0
                 t = timesteps[step]
                 t_prev_list = [t]
+                self.cur_step = step
                 model_prev_list = [self.model_fn(x, t)]
                 if self.correcting_xt_fn is not None:
                     x = self.correcting_xt_fn(x, t, step)
@@ -1535,6 +1552,7 @@ class DPM_Solver:
                 # Init the first `order` values by lower order multistep DPM-Solver.
                 for step in range(1, order):
                     t = timesteps[step]
+                    self.cur_step = step
                     x = self.multistep_dpm_solver_update(
                         x, model_prev_list, t_prev_list, t, step, solver_type=solver_type
                     )
@@ -1549,6 +1567,7 @@ class DPM_Solver:
                 # Compute the remaining values by `order`-th order multistep DPM-Solver.
                 for step in tqdm(range(order, steps + 1), disable=os.getenv("DPM_TQDM", "False") == "True"):
                     t = timesteps[step]
+                    self.cur_step = step
                     # We only use lower order for steps < 10
                     # if lower_order_final and steps < 10:
                     if lower_order_final:  # recommended by Shuchen Xue
@@ -1568,6 +1587,7 @@ class DPM_Solver:
                     t_prev_list[-1] = t
                     # We do not need to evaluate the final model value.
                     if step < steps:
+                        self.cur_step = step
                         model_prev_list[-1] = self.model_fn(x, t)
                     # update progress bar
                     self.update_progress(step + 1, len(timesteps))
@@ -1582,8 +1602,10 @@ class DPM_Solver:
                         order,
                     ] * K
                     timesteps_outer = self.get_time_steps(skip_type=skip_type, t_T=t_T, t_0=t_0, N=K, device=device)
+                self.cur_step = 0
                 for step, order in enumerate(orders):
                     s, t = timesteps_outer[step], timesteps_outer[step + 1]
+                    self.cur_step = step
                     timesteps_inner = self.get_time_steps(
                         skip_type=skip_type, t_T=s.item(), t_0=t.item(), N=order, device=device
                     )

--- a/diffusion/scheduler/dpm_solver.py
+++ b/diffusion/scheduler/dpm_solver.py
@@ -34,6 +34,8 @@ def DPMS(
     diffusion_steps=1000,
     schedule="VP",
     interval_guidance=None,
+    second_model=None,
+    switch_step=None,
 ):
     if pag_applied_layers is None:
         pag_applied_layers = []
@@ -65,5 +67,23 @@ def DPMS(
         guidance_scale=cfg_scale,
         interval_guidance=interval_guidance,
     )
-    ## 3. Define dpm-solver and sample by multistep DPM-Solver.
-    return DPM_Solver(model_fn, noise_schedule, algorithm_type="dpmsolver++")
+    ## 3. Define dpm-solver and optionally register a secondary model
+    solver = DPM_Solver(model_fn, noise_schedule, algorithm_type="dpmsolver++")
+
+    if second_model is not None and switch_step is not None:
+        second_fn = model_wrapper(
+            second_model,
+            noise_schedule,
+            model_type=model_type,
+            model_kwargs=model_kwargs,
+            guidance_type=guidance_type,
+            pag_scale=pag_scale,
+            pag_applied_layers=pag_applied_layers,
+            condition=condition,
+            unconditional_condition=uncondition,
+            guidance_scale=cfg_scale,
+            interval_guidance=interval_guidance,
+        )
+        solver.set_secondary_model(second_fn, switch_step)
+
+    return solver


### PR DESCRIPTION
## Summary
- allow SanaPipeline to accept an optional secondary model and step ratio
- extend DPMS and DPM_Solver to switch models after a specified step

## Testing
- `pre-commit run --files diffusion/scheduler/dpm_solver.py diffusion/model/dpm_solver.py app/sana_pipeline.py`
- `pytest` *(fails: fixture 'mocker' not found in tools/metrics tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bf50a25e0483228f593d365d328b22